### PR TITLE
refactor(experience): fix didcommagent state enum typo

### DIFF
--- a/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent.swift
@@ -7,14 +7,14 @@ import Foundation
 public class DIDCommAgent {
     /// Enumeration representing the current state of the agent.
     public enum State: String {
-        case stoped
+        case stopped
         case starting
         case running
-        case stoping
+        case stopping
     }
     
     /// Represents the current state of the agent.
-    public private(set) var state = State.stoped
+    public private(set) var state = State.stopped
     
     /// The mediator routing DID if one is currently registered.
     public var mediatorRoutingDID: DID? {
@@ -129,7 +129,7 @@ public class DIDCommAgent {
     public func start() async throws {
         guard
             let connectionManager,
-            state == .stoped
+            state == .stopped
         else { return }
         logger.info(message: "Starting agent")
         state = .starting
@@ -149,19 +149,19 @@ public class DIDCommAgent {
 
     /**
       This function is used to stop the EdgeAgent.
-      The function sets the state of EdgeAgent to .stoping.
+      The function sets the state of EdgeAgent to .stopping.
       All ongoing events that was created by the EdgeAgent are stopped.
-      After all the events are stopped the state of the EdgeAgent is set to .stoped.
+      After all the events are stopped the state of the EdgeAgent is set to .stopped.
 
       - Throws: If the current state is not running throws error.
       */
      public func stop() async throws {
          guard state == .running else { return }
-         logger.info(message: "Stoping agent")
-         state = .stoping
+         logger.info(message: "Stopping agent")
+         state = .stopping
          cancellables.forEach { $0.cancel() }
          connectionManager?.stopAllEvents()
-         state = .stoped
+         state = .stopped
          logger.info(message: "Agent not running")
      }
 }


### PR DESCRIPTION
### Description: 
Summarize the changes you're submitting in a few sentences, including Jira ticket ATL-xxxx if applicable.
Link to any discussion, related issues and bug reports to give the context to help the reviewer understand the PR.

Fix typo in DIDCommAgent State enum value.  Should not break SDK however potential for downstream breaking change if users have relied on the misspelling in their consumer code.

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
